### PR TITLE
feat(docker): use the dockerfile-maven-plugin to build Docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ branches:
 after_success:
 - test "${TRAVIS_PULL_REQUEST}" == "false" && test "${TRAVIS_TAG}" != "" && mvn deploy --settings travis-settings.xml
 
+sudo: required
+
+services:
+  - docker
+
 env:
   global:
   # travis encrypt BINTRAY_USER=[username]

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ To build and start a container including the PostGIS database run:
 
 ```
 mvn clean install
-docker-compose up --build
+docker-compose up
 ```
 
 All data is stored inside the PostGIS database. To keep this state there's a volume automatically mapped to the PostGIS container.

--- a/SensorThingsServer/Dockerfile
+++ b/SensorThingsServer/Dockerfile
@@ -4,4 +4,5 @@ ADD http://repo.maven.apache.org/maven2/org/postgresql/postgresql/9.4.1212/postg
 ADD http://repo.maven.apache.org/maven2/net/postgis/postgis-jdbc/2.2.1/postgis-jdbc-2.2.1.jar /usr/local/tomcat/lib/
 
 # Copy to images tomcat path
-ADD ./SensorThingsServer/target/SensorThingsServer-1.4-SNAPSHOT.war /usr/local/tomcat/webapps/SensorThingsService.war
+ARG WAR_FILE
+ADD target/${WAR_FILE} /usr/local/tomcat/webapps/SensorThingsService.war

--- a/SensorThingsServer/pom.xml
+++ b/SensorThingsServer/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <docker-image-name>sensorthings-server</docker-image-name>
     </properties>
 
     <dependencies>
@@ -114,6 +115,51 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <version>${dockerfile-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>tag-version</id>
+                        <goals>
+                            <goal>tag</goal>
+                        </goals>
+                        <configuration>
+                            <tag>${project.version}</tag>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tag-latest</id>
+                        <goals>
+                            <goal>tag</goal>
+                        </goals>
+                        <configuration>
+                            <tag>latest</tag>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <repository>${docker-image-name}</repository>
+                    <buildArgs>
+                        <WAR_FILE>${project.build.finalName}.war</WAR_FILE>
+                    </buildArgs>
+                </configuration>
+                <dependencies>
+                    <!-- Java 9 support -->
+                    <dependency>
+                        <groupId>javax.activation</groupId>
+                        <artifactId>activation</artifactId>
+                        <version>${javax-activation.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   web:
-    build: .
+    image: sensorthings-server:latest
     ports:
       - 8080:8080
     depends_on:

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,9 @@
         <querydsl.version>4.1.4</querydsl.version>
         <slf4j-api.version>1.7.20</slf4j-api.version>
 
+        <javax-activation.version>1.1.1</javax-activation.version>
+        <dockerfile-maven-plugin.version>1.3.7</dockerfile-maven-plugin.version>
+
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <builddatabase.driver>org.h2.Driver</builddatabase.driver>
         <builddatabase.url>jdbc:h2:${project.basedir}/target/builddb/h2</builddatabase.url>


### PR DESCRIPTION
Hi,

As proposed in #39, this PR adds the use of the [Spotify's dockerfile-maven-plugin](https://github.com/spotify/dockerfile-maven) to build Docker image against Maven. Then Docker image creation is now included during Maven build (and more generally during Maven phases as explained in the [documentation](https://github.com/spotify/dockerfile-maven#faster-build-times)).
This way, no more version handling in the Dockerfile (for instance), because Docker image now follows the whole project lifecycle.

Note this PR changes a bit how Docker image is created and used:
- Image has now a name, `sensorthings-server`. From now, this name is not related to any Docker repository. Please update it when #38 will be resolved.
- 2 tags is created each time a package is created (i.e., during the Maven's package phase) : one that follows the current project's version and an other one, `latest`, that is a copy of the first tag.
- The `docker-compose.yaml` file is now linked to the `sensortings-server:latest` image. So, no more build with  `docker-compose`, any image build is now handled by the `dockerfile-maven` plugin, and so, via Maven. 

Note also that any Docker actions during Maven operations can be skipped, as explained in the associated [documentation](https://github.com/spotify/dockerfile-maven#skip-docker-goals-bound-to-maven-phases).

Regards,
Aurélien